### PR TITLE
fix issue #4, gem changes behavior of integer division

### DIFF
--- a/lib/distribution/math_extension.rb
+++ b/lib/distribution/math_extension.rb
@@ -11,7 +11,46 @@ require "distribution/math_extension/log_utilities"
 
 
 if RUBY_VERSION<"1.9"
-  require 'mathn'
+  class Prime
+    include Enumerable
+
+    def initialize
+      @seed = 1
+      @primes = []
+      @counts = []
+    end
+
+    def succ
+      i = -1
+      size = @primes.size
+      while i < size
+        if i == -1
+    @seed += 1
+    i += 1
+        else
+    while @seed > @counts[i]
+      @counts[i] += @primes[i]
+    end
+    if @seed != @counts[i]
+      i += 1
+    else
+      i = -1
+    end
+        end
+      end
+      @primes.push @seed
+      @counts.push @seed + @seed
+      return @seed
+    end
+    alias next succ
+
+    def each
+      loop do
+        yield succ
+      end
+    end
+  end
+
   def Prime.each(upper,&block) 
     @primes=Prime.new
     @primes.each do |prime|


### PR DESCRIPTION
gem only changes behavior of integer division in ruby versions < 1.9, because it includes mathn in order to use Prime. But mathn has the side effect of changing integer division.  Instead of including mathn, we can just copy the Prime code from ruby 1.8.7 in the one line where mathn is called.  
