### PR TITLE
bugfix for large values in normal cdf

### DIFF
--- a/lib/distribution/normal/ruby.rb
+++ b/lib/distribution/normal/ruby.rb
@@ -63,9 +63,9 @@ module Distribution
         # over (-Infty, z].
         # 
         def cdf(z)
-          0.0 if z < -12 
-          1.0 if z > 12
-          0.5 if z == 0.0 
+          return 0.0 if z < -12 
+          return 1.0 if z > 12
+          return 0.5 if z == 0.0 
 
           if z > 0.0
             e = true


### PR DESCRIPTION
Distribution::Normal.cdf(x) was returning 0.5 for absolute values over 38, probably due to some overflow or numeric error. These cases should be covered by the changed lines, except that these lines weren't actually doing anything other than evaluating and carrying on.
