### PR TITLE
Fix beta distribution quantiles

### DIFF
--- a/lib/distribution/beta/ruby.rb
+++ b/lib/distribution/beta/ruby.rb
@@ -53,7 +53,7 @@ module Distribution
             guess = (ga + gb) / 2.0
             result = cdf(guess, a, b)
 
-            if (result == p) || (result == 0)
+            if result == p
               gb = ga
             elsif result > p
               gb = guess

--- a/spec/beta_spec.rb
+++ b/spec/beta_spec.rb
@@ -46,6 +46,16 @@ describe Distribution::Beta do
         skip("No #{@engine}.p_value")
       end
     end
+
+    it 'should return correct quantile' do
+      if @engine.respond_to? :quantile
+        tol = 1_048_576.0 * Float::EPSILON
+        @engine.quantile(0.86, 1076, 1).should be_within(tol).of(0.9998598398514792)
+        @engine.quantile(0.3, 10_000, 10_000).should be_within(tol).of(0.4981459474049274)
+      else
+        skip("No #{@engine}.quantile")
+      end
+    end
   end
 
   describe 'singleton' do


### PR DESCRIPTION
This fixes ruby implementation of `p_value` and `quantile` for beta distribution which are broken for high values of `a` and `b`.

For example `quantile(0.86, 1076, 1)` returns `0.5` while it should return a number close to 1, `quantile(0.3, 10_000, 10_000)` returns `0.25` while expected result is ~0.5.